### PR TITLE
feat: 熊二

### DIFF
--- a/src/apps/ab.xer.ts
+++ b/src/apps/ab.xer.ts
@@ -15,7 +15,7 @@ export default defineGkdApp({
       rules: [
         {
           activityIds: '.page.activity.MainActivity',
-          matches: ['[text="通知服务未开启"]', '[text="取消"]'],
+          matches: ['[text"通知服务未开启"]', '[text="取消"'],
           snapshotUrls: 'https://i.gkd.li/i/26462136',
           exampleUrls: 'https://e.gkd.li/e335f324-0d13-4023-8640-d6d03d8f9250',
         },

--- a/src/apps/ab.xer.ts
+++ b/src/apps/ab.xer.ts
@@ -16,7 +16,8 @@ export default defineGkdApp({
         {
           activityIds: '.page.activity.MainActivity',
           matches: ['[text="通知服务未开启"]', '[text="取消"]'],
-          snapshotUrls: 'https://i.gkd.li/i/114514',
+          snapshotUrls: 'https://i.gkd.li/i/26462136',
+          exampleUrls: 'https://e.gkd.li/e335f324-0d13-4023-8640-d6d03d8f9259',
         },
       ],
     },

--- a/src/apps/ab.xer.ts
+++ b/src/apps/ab.xer.ts
@@ -1,0 +1,24 @@
+import { defineGkdApp } from '@gkd-kit/define';
+
+export default defineGkdApp({
+  id: 'ab.xer',
+  name: '熊二',
+  groups: [
+    {
+      key: 1,
+      name: '权限提示-通知权限',
+      desc: '点击[取消]',
+      fastQuery: true,
+      matchTime: 10000,
+      actionMaximum: 1,
+      resetMatch: 'app',
+      rules: [
+        {
+          activityIds: '.page.activity.MainActivity',
+          matches: ['[text="通知服务未开启"]', '[text="取消"]'],
+          snapshotUrls: 'https://i.gkd.li/i/114514',
+        },
+      ],
+    },
+  ],
+});

--- a/src/apps/ab.xer.ts
+++ b/src/apps/ab.xer.ts
@@ -17,7 +17,7 @@ export default defineGkdApp({
           activityIds: '.page.activity.MainActivity',
           matches: ['[text="通知服务未开启"]', '[text="取消"]'],
           snapshotUrls: 'https://i.gkd.li/i/26462136',
-          exampleUrls: 'https://e.gkd.li/e335f324-0d13-4023-8640-d6d03d8f9259',
+          exampleUrls: 'https://e.gkd.li/e335f324-0d13-4023-8640-d6d03d8f9250',
         },
       ],
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the "熊二" app with automated handling of notification-service prompts, including recognition of the "通知服务未开启" and "取消" UI texts and associated example/snapshot references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->